### PR TITLE
Partially fix #104 by introducing Redis caching

### DIFF
--- a/apps/api/.env.development.example
+++ b/apps/api/.env.development.example
@@ -1,9 +1,22 @@
+# Database connection settings
 DATABASE_HOST=postgrex
 DATABASE_PORT=5432
 DATABASE_USER=postgres
 DATABASE_PASSWORD=password
 DATABASE_NAME=agmap
+
+# Redis config
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+
+# Map clustering configuration
 MAP_CLUSTER_RADIUS=80
 MAP_CLUSTER_MAX_ZOOM=8
-API_KEY_OPENAQ=randomapikeystring
+MAP_CLUSTER_TTL_SECONDS=900
+
+# External API key for OpenAQ service
+API_KEY_OPENAQ=your-openaq-api-key-here
+
+# Application server settings
 PORT=3001

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.9",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "ioredis": "^5.6.1",
         "pg": "^8.13.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -181,13 +182,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -313,7 +316,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -321,7 +326,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -337,23 +344,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.28.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -568,13 +579,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -606,12 +619,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
+      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1214,6 +1229,12 @@
         }
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1611,7 +1632,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2142,6 +2165,19 @@
         }
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2188,6 +2224,16 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0",
         "npm": ">=5.10.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3119,7 +3165,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3298,7 +3346,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3650,6 +3700,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -3953,6 +4012,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -4335,7 +4403,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4909,13 +4979,18 @@
       }
     },
     "node_modules/formidable": {
-      "version": "3.5.2",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -5178,14 +5253,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hexoid": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
@@ -5317,6 +5384,30 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5544,7 +5635,9 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5708,7 +5801,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6028,7 +6123,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6365,6 +6462,18 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -7380,6 +7489,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "license": "Apache-2.0"
@@ -7856,6 +7986,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8215,7 +8351,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.7.9",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "ioredis": "^5.6.1",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
-import DatabaseModule from './database/database.module';
-import { TasksModule } from './tasks/tasks.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
+
+import DatabaseModule from './database/database.module';
+import RedisCacheModule from './redis-cache/redis-cache.module';
+import { TasksModule } from './tasks/tasks.module';
 import { MeasurementModule } from './measurement/measurement.module';
 import { LocationModule } from './location/location.module';
 
@@ -23,6 +25,15 @@ import { LocationModule } from './location/location.module';
         user: configService.get('DATABASE_USER'),
         password: configService.get('DATABASE_PASSWORD'),
         database: configService.get('DATABASE_NAME'),
+      }),
+    }),
+    RedisCacheModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        host: configService.get('REDIS_HOST'),
+        port: +configService.get<number>('REDIS_PORT'),
+        db: +configService.get<number>('REDIS_DB') || 0,
       }),
     }),
     MeasurementModule,

--- a/apps/api/src/config/swagger.config.ts
+++ b/apps/api/src/config/swagger.config.ts
@@ -25,7 +25,7 @@ All coordinates use **WGS84**: Longitude (-180° to +180°), Latitude (-90° to 
 - Updates every 5-15 minutes
 `,
     )
-    .setVersion('1.0')
+    .setVersion('0.0.1')
     .setContact(
       'AirGradient Support',
       'https://www.airgradient.com/support/',

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -40,7 +40,7 @@ async function bootstrap() {
     },
   });
 
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3001);
   logger.log('Application Started');
 }
 bootstrap();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -33,7 +33,12 @@ async function bootstrap() {
   // Setup Swagger
   const swaggerConfig = createSwaggerConfig();
   const documentFactory = () => SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('map/api/v1/docs', app, documentFactory);
+
+  SwaggerModule.setup('map/api/v1/docs', app, documentFactory, {
+    swaggerOptions: {
+      displayRequestDuration: true,
+    },
+  });
 
   await app.listen(process.env.PORT ?? 3000);
   logger.log('Application Started');

--- a/apps/api/src/redis-cache/redis-cache.module-definition.ts
+++ b/apps/api/src/redis-cache/redis-cache.module-definition.ts
@@ -1,5 +1,5 @@
 import { ConfigurableModuleBuilder } from '@nestjs/common';
-import RedisCacheOptions from './redis-cache.options';
+import { RedisCacheOptions } from './redis-cache.options';
 
 export const CONNECTION_POOL = 'REDIS_CONNECTION';
 

--- a/apps/api/src/redis-cache/redis-cache.module-definition.ts
+++ b/apps/api/src/redis-cache/redis-cache.module-definition.ts
@@ -1,0 +1,9 @@
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+import RedisCacheOptions from './redis-cache.options';
+
+export const CONNECTION_POOL = 'REDIS_CONNECTION';
+
+export const {
+  ConfigurableModuleClass: ConfigurableRedisCacheModule,
+  MODULE_OPTIONS_TOKEN: REDIS_CACHE_OPTIONS,
+} = new ConfigurableModuleBuilder<RedisCacheOptions>().setClassMethodName('forRoot').build();

--- a/apps/api/src/redis-cache/redis-cache.module.ts
+++ b/apps/api/src/redis-cache/redis-cache.module.ts
@@ -1,0 +1,29 @@
+import { Global, Module } from '@nestjs/common';
+import Redis from 'ioredis';
+import {
+  ConfigurableRedisCacheModule,
+  CONNECTION_POOL,
+  REDIS_CACHE_OPTIONS,
+} from './redis-cache.module-definition';
+import RedisCacheService from './redis-cache.service';
+import RedisCacheOptions from './redis-cache.options';
+
+@Global()
+@Module({
+  exports: [RedisCacheService],
+  providers: [
+    RedisCacheService,
+    {
+      provide: CONNECTION_POOL,
+      inject: [REDIS_CACHE_OPTIONS],
+      useFactory: (redisOptions: RedisCacheOptions) => {
+        return new Redis({
+          host: redisOptions.host,
+          port: redisOptions.port,
+          db: redisOptions.db,
+        });
+      },
+    },
+  ],
+})
+export default class RedisCacheModule extends ConfigurableRedisCacheModule {}

--- a/apps/api/src/redis-cache/redis-cache.module.ts
+++ b/apps/api/src/redis-cache/redis-cache.module.ts
@@ -5,8 +5,8 @@ import {
   CONNECTION_POOL,
   REDIS_CACHE_OPTIONS,
 } from './redis-cache.module-definition';
-import RedisCacheService from './redis-cache.service';
-import RedisCacheOptions from './redis-cache.options';
+import { RedisCacheService } from './redis-cache.service';
+import { RedisCacheOptions } from './redis-cache.options';
 
 @Global()
 @Module({

--- a/apps/api/src/redis-cache/redis-cache.options.ts
+++ b/apps/api/src/redis-cache/redis-cache.options.ts
@@ -1,7 +1,5 @@
-interface RedisCacheOptions {
+export interface RedisCacheOptions {
   host: string;
   port: number;
   db: number;
 }
-
-export default RedisCacheOptions;

--- a/apps/api/src/redis-cache/redis-cache.options.ts
+++ b/apps/api/src/redis-cache/redis-cache.options.ts
@@ -1,0 +1,7 @@
+interface RedisCacheOptions {
+  host: string;
+  port: number;
+  db: number;
+}
+
+export default RedisCacheOptions;

--- a/apps/api/src/redis-cache/redis-cache.service.spec.ts
+++ b/apps/api/src/redis-cache/redis-cache.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import RedisCacheService from './redis-cache.service';
+import { RedisCacheService } from './redis-cache.service';
 
 describe('RedisCacheService', () => {
   let service: RedisCacheService;

--- a/apps/api/src/redis-cache/redis-cache.service.spec.ts
+++ b/apps/api/src/redis-cache/redis-cache.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import RedisCacheService from './redis-cache.service';
+
+describe('RedisCacheService', () => {
+  let service: RedisCacheService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RedisCacheService],
+    }).compile();
+
+    service = module.get<RedisCacheService>(RedisCacheService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/redis-cache/redis-cache.service.ts
+++ b/apps/api/src/redis-cache/redis-cache.service.ts
@@ -1,0 +1,60 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { CONNECTION_POOL } from './redis-cache.module-definition';
+
+@Injectable()
+export default class RedisCacheService {
+  private readonly logger = new Logger(RedisCacheService.name);
+
+  constructor(@Inject(CONNECTION_POOL) private readonly client: Redis) {}
+
+  async get(key: string): Promise<string | null> {
+    try {
+      const result = await this.client.get(key);
+      this.logger.log(`Redis command: GET ${key} => ${result ? 'hit' : 'miss'}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Redis command failed: GET ${key} - ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<'OK' | null> {
+    try {
+      let result: 'OK';
+      if (ttlSeconds) {
+        result = await this.client.set(key, value, 'EX', ttlSeconds);
+        this.logger.log(`Redis command: SET ${key} EX ${ttlSeconds}`);
+      } else {
+        result = await this.client.set(key, value);
+        this.logger.log(`Redis command: SET ${key}`);
+      }
+      return result;
+    } catch (error) {
+      this.logger.error(`Redis command failed: SET ${key} - ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async del(key: string): Promise<number> {
+    try {
+      const result = await this.client.del(key);
+      this.logger.log(`Redis command: DEL ${key} => ${result}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Redis command failed: DEL ${key} - ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async flushdb(): Promise<string | null> {
+    try {
+      const result = await this.client.flushdb();
+      this.logger.log(`Redis command: FLUSHDB => ${result}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Redis command failed: FLUSHDB - ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/redis-cache/redis-cache.service.ts
+++ b/apps/api/src/redis-cache/redis-cache.service.ts
@@ -3,7 +3,7 @@ import Redis from 'ioredis';
 import { CONNECTION_POOL } from './redis-cache.module-definition';
 
 @Injectable()
-export default class RedisCacheService {
+export class RedisCacheService {
   private readonly logger = new Logger(RedisCacheService.name);
 
   constructor(@Inject(CONNECTION_POOL) private readonly client: Redis) {}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,6 +17,16 @@ services:
       - POSTGRES_USER=${DATABASE_USER}
     networks:
       - dev
+  
+  redis:
+    container_name: redis-mono
+    image: redis:8-alpine
+    ports:
+      - 6379:6379
+    volumes:
+      - redisdata:/data
+    networks:
+      - dev
 
   mapapi:
     container_name: mapapi-mono
@@ -32,6 +42,7 @@ services:
       - dev
     depends_on:
       - postgrex
+      - redis
 
   app:
     container_name: website-mono
@@ -56,4 +67,4 @@ networks:
 
 volumes:
   pgdata:
-
+  redisdata:


### PR DESCRIPTION
This PR addresses [Issue #104](https://github.com/airgradienthq/airgradient-map/issues/104).

**[major]**
- Introduce Redis container using `redis:8-alpine` image
- Add redis-cache module
- Cache the response of the `getLastMeasurementsByCluster` function, which corresponds to the `/map/api/v1/measurements/current/cluster` endpoint
- Use cache key format: `cluster:${xMin}:${yMin}:${xMax}:${yMax}:${zoom}:${measurementType}`
- Set TTL to `15` minutes
- Flush Redis DB after fetching data from the AirGradient API via a 15-minute cron job

**[minor]**
- Correct API docs URL to use port `3001` instead of `3000`
- Enable request duration display in Swagger UI to compare performance before and after changes
- Correct Swagger version to `0.0.1` to match package.json
- Prettify `.env.development.example` file

**[Result]**
- payload: `measure=pm25&xmin=0&ymin=0&xmax=180&ymax=180&zoom=1'`
- First request (cache miss): 282 ms
- Subsequent requests (cache hit): 53 ms

**Note:**
This is my first time contributing to an open-source project, so I’m not sure if I opened this PR correctly. Should I link it to a specific issue ID? I believe I should, but I haven’t found a way to do so yet.

I’m also not sure if I branched correctly from the main branch. I think normally it should branch from the development branch, but currently, the main branch seems more up-to-date than the development branch.

This is also my first time writing NestJS code (I come from a Python/FastAPI background), so the code might not fully follow best practices, but I’ve done my best.

I apologize if anything is incorrect, and I would sincerely appreciate any suggestions or guidance on how to improve. Thank you very much for your patience and help!