### PR TITLE
fix: skip epa correction for OpenAQ locations

### DIFF
--- a/apps/api/src/location/location.repository.ts
+++ b/apps/api/src/location/location.repository.ts
@@ -110,18 +110,20 @@ class LocationRepository {
   async retrieveLastMeasuresByLocationId(id: number) {
     const query = `
             SELECT 
-                location_id AS "locationId",
-                pm25,
-                pm10,
-                atmp,
-                rhum,
-                rco2,
-                o3,
-                no2,
-                measured_at AS "measuredAt"
-            FROM measurement
-            WHERE location_id = $1
-            ORDER BY measured_at DESC 
+                m.location_id AS "locationId",
+                m.pm25,
+                m.pm10,
+                m.atmp,
+                m.rhum,
+                m.rco2,
+                m.o3,
+                m.no2,
+                m.measured_at AS "measuredAt",
+                l.sensor_type AS "sensorType"
+            FROM measurement m
+            JOIN location l ON m.location_id = l.id
+            WHERE m.location_id = $1
+            ORDER BY m.measured_at DESC 
             LIMIT 1;
         `;
 
@@ -200,13 +202,15 @@ class LocationRepository {
     const query = `
             SELECT
                 date_bin($4, m.measured_at, $2) AS timebucket,
-                ${selectClause}
-            FROM measurement m 
+                ${selectClause},
+                l.sensor_type AS sensorType
+            FROM measurement m
+            JOIN location l on m.location_id = l.id
             WHERE 
                 m.location_id = $1 AND 
                 m.measured_at BETWEEN $2 AND $3 
                 ${validationQuery}
-            GROUP BY timebucket
+            GROUP BY timebucket, sensorType
             ORDER BY timebucket;
         `;
 

--- a/apps/api/src/location/location.repository.ts
+++ b/apps/api/src/location/location.repository.ts
@@ -119,7 +119,8 @@ class LocationRepository {
                 m.o3,
                 m.no2,
                 m.measured_at AS "measuredAt",
-                l.sensor_type AS "sensorType"
+                l.sensor_type AS "sensorType",
+                l.data_source AS "dataSource"
             FROM measurement m
             JOIN location l ON m.location_id = l.id
             WHERE m.location_id = $1
@@ -203,14 +204,15 @@ class LocationRepository {
             SELECT
                 date_bin($4, m.measured_at, $2) AS timebucket,
                 ${selectClause},
-                l.sensor_type AS sensorType
+                l.sensor_type AS sensorType,
+                l.data_source AS dataSource
             FROM measurement m
             JOIN location l on m.location_id = l.id
             WHERE 
                 m.location_id = $1 AND 
                 m.measured_at BETWEEN $2 AND $3 
                 ${validationQuery}
-            GROUP BY timebucket, sensorType
+            GROUP BY timebucket, sensorType, dataSource
             ORDER BY timebucket;
         `;
 

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -17,7 +17,7 @@ export class LocationService {
 
   async getLocationLastMeasures(id: number) {
     const results = await this.locationRepository.retrieveLastMeasuresByLocationId(id);
-    if (results.sensorType == 'Small Sensor') {
+    if (results.dataSource === 'AirGradient') {
       results.pm25 = getEPACorrectedPM(results.pm25, results.rhum);
     }
     return results;
@@ -47,7 +47,7 @@ export class LocationService {
     if (measureType === 'pm25') {
       return results.map(row => ({
         timebucket: row.timebucket,
-        value: row.sensorType == 'Small Sensor' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
+        value: row.dataSource === 'AirGradient' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
       }));
     }
 

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -17,7 +17,7 @@ export class LocationService {
 
   async getLocationLastMeasures(id: number) {
     const results = await this.locationRepository.retrieveLastMeasuresByLocationId(id);
-    if (results.sensorType !== 'Reference') {
+    if (results.sensorType == 'Small Sensor') {
       results.pm25 = getEPACorrectedPM(results.pm25, results.rhum);
     }
     return results;
@@ -47,7 +47,7 @@ export class LocationService {
     if (measureType === 'pm25') {
       return results.map(row => ({
         timebucket: row.timebucket,
-        value: row.sensorType !== 'Reference' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
+        value: row.sensorType == 'Small Sensor' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
       }));
     }
 

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -17,7 +17,9 @@ export class LocationService {
 
   async getLocationLastMeasures(id: number) {
     const results = await this.locationRepository.retrieveLastMeasuresByLocationId(id);
-    results.pm25 = getEPACorrectedPM(results.pm25, results.rhum);
+    if (results.sensorType !== 'Reference') {
+      results.pm25 = getEPACorrectedPM(results.pm25, results.rhum);
+    }
     return results;
   }
 
@@ -45,7 +47,7 @@ export class LocationService {
     if (measureType === 'pm25') {
       return results.map(row => ({
         timebucket: row.timebucket,
-        value: getEPACorrectedPM(row.pm25, row.rhum),
+        value: row.sensorType !== 'Reference' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
       }));
     }
 

--- a/apps/api/src/measurement/measurement.entity.ts
+++ b/apps/api/src/measurement/measurement.entity.ts
@@ -40,6 +40,9 @@ export class MeasurementEntity {
   @ApiProperty()
   measuredAt: Date;
 
+  @ApiProperty()
+  dataSource: string;
+
   constructor(partial: Partial<MeasurementEntity>) {
     Object.assign(this, partial);
   }

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -40,7 +40,7 @@ class MeasurementRepository {
 
       if (measure === 'pm25') {
         query.selectQuery = `m.pm25, m.rhum`;
-        query.whereQuery = `WHERE m.pm25 IS NOT NULL AND m.rhum IS NOT NULL ${validationQuery}`;
+        query.whereQuery = `WHERE m.pm25 IS NOT NULL ${validationQuery}`;
       } else {
         query.selectQuery = `m.${measure}`;
         query.whereQuery = `WHERE m.${measure} IS NOT NULL ${validationQuery}`;

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -157,7 +157,8 @@ class MeasurementRepository {
                 ST_Y(l.coordinate) AS latitude,
                 l.sensor_type AS "sensorType",
                 ${selectQuery},
-                lm.last_measured_at AS "measuredAt"
+                lm.last_measured_at AS "measuredAt",
+                l.data_source AS "dataSource"
             FROM 
                 latest_measurements lm
             JOIN 

--- a/apps/api/src/measurement/measurement.service.ts
+++ b/apps/api/src/measurement/measurement.service.ts
@@ -79,7 +79,10 @@ export class MeasurementService {
     // converting to .geojson features array
     let geojson = new Array<any>();
     locations.map(point => {
-      const value = measure === 'pm25' ? getEPACorrectedPM(point.pm25, point.rhum) : point[measure];
+      const value =
+        measure === 'pm25' && point.sensorType !== 'Reference'
+          ? getEPACorrectedPM(point.pm25, point.rhum)
+          : point[measure];
       geojson.push({
         type: 'Feature',
         geometry: {
@@ -123,7 +126,7 @@ export class MeasurementService {
 
   private setEPACorrectedPM(measurements: MeasurementEntity[]) {
     return measurements.map(point => {
-      if (point.pm25 || point.pm25 === 0) {
+      if ((point.sensorType !== 'Reference' && point.pm25) || point.pm25 === 0) {
         point.pm25 = getEPACorrectedPM(point.pm25, point.rhum);
       }
       return point;

--- a/apps/api/src/measurement/measurement.service.ts
+++ b/apps/api/src/measurement/measurement.service.ts
@@ -80,7 +80,7 @@ export class MeasurementService {
     let geojson = new Array<any>();
     locations.map(point => {
       const value =
-        measure === 'pm25' && point.sensorType !== 'Reference'
+        measure === 'pm25' && point.sensorType == 'Small Sensor'
           ? getEPACorrectedPM(point.pm25, point.rhum)
           : point[measure];
       geojson.push({
@@ -126,7 +126,7 @@ export class MeasurementService {
 
   private setEPACorrectedPM(measurements: MeasurementEntity[]) {
     return measurements.map(point => {
-      if ((point.sensorType !== 'Reference' && point.pm25) || point.pm25 === 0) {
+      if ((point.sensorType == 'Small Sensor' && point.pm25) || point.pm25 === 0) {
         point.pm25 = getEPACorrectedPM(point.pm25, point.rhum);
       }
       return point;

--- a/apps/api/src/measurement/measurement.service.ts
+++ b/apps/api/src/measurement/measurement.service.ts
@@ -80,7 +80,7 @@ export class MeasurementService {
     let geojson = new Array<any>();
     locations.map(point => {
       const value =
-        measure === 'pm25' && point.sensorType == 'Small Sensor'
+        measure === 'pm25' && point.dataSource === 'AirGradient'
           ? getEPACorrectedPM(point.pm25, point.rhum)
           : point[measure];
       geojson.push({
@@ -93,6 +93,7 @@ export class MeasurementService {
           locationId: point.locationId,
           locationName: point.locationName,
           sensorType: point.sensorType,
+          dataSource: point.dataSource,
           value,
         },
       });
@@ -126,7 +127,7 @@ export class MeasurementService {
 
   private setEPACorrectedPM(measurements: MeasurementEntity[]) {
     return measurements.map(point => {
-      if ((point.sensorType == 'Small Sensor' && point.pm25) || point.pm25 === 0) {
+      if (point.dataSource === 'AirGradient' && (point.pm25 || point.pm25 === 0)) {
         point.pm25 = getEPACorrectedPM(point.pm25, point.rhum);
       }
       return point;

--- a/apps/api/src/measurement/measurementCluster.model.ts
+++ b/apps/api/src/measurement/measurementCluster.model.ts
@@ -25,6 +25,9 @@ class MeasurementCluster {
   })
   sensorType?: string;
 
+  @ApiPropertyOptional({ description: 'Field available if type is sensor' })
+  dataSource?: string;
+
   @ApiProperty({
     description:
       'Measurement value based on measure query provided; if type is cluster, value is averaged',
@@ -41,6 +44,7 @@ class MeasurementCluster {
       this.locationId = clusters.properties.locationId;
       this.locationName = clusters.properties.locationName;
       this.sensorType = clusters.properties.sensorType;
+      this.dataSource = clusters.properties.dataSource;
       this.value = Math.round(clusters.properties.value);
     }
 


### PR DESCRIPTION
issue #224 

Checked the sensor type before applying EPA correction formula.

Removed rhum from the where clause in buildMeasureQuery(), which filtered out OpenAQ results.