### PR TITLE
Fix swapped latitude and longitude ordering across frontend, backend, and database

### DIFF
--- a/apps/api/src/measurement/measurement.service.ts
+++ b/apps/api/src/measurement/measurement.service.ts
@@ -87,7 +87,7 @@ export class MeasurementService {
         type: 'Feature',
         geometry: {
           type: 'Point',
-          coordinates: [point.latitude, point.longitude],
+          coordinates: [point.longitude, point.latitude],
         },
         properties: {
           locationId: point.locationId,

--- a/apps/api/src/measurement/measurement.service.ts
+++ b/apps/api/src/measurement/measurement.service.ts
@@ -114,7 +114,7 @@ export class MeasurementService {
         },
       });
       clustersIndexes.load(geojson);
-      clusters = clustersIndexes.getClusters([yMin, xMin, yMax, xMax], zoom);
+      clusters = clustersIndexes.getClusters([xMin, yMin, xMax, yMax], zoom);
     }
 
     // Map to to array of MeasurementClusterModel

--- a/apps/api/src/measurement/measurementCluster.model.ts
+++ b/apps/api/src/measurement/measurementCluster.model.ts
@@ -48,8 +48,8 @@ class MeasurementCluster {
       this.value = Math.round(clusters.properties.value);
     }
 
-    this.latitude = clusters.geometry.coordinates[0];
-    this.longitude = clusters.geometry.coordinates[1];
+    this.latitude = clusters.geometry.coordinates[1];
+    this.longitude = clusters.geometry.coordinates[0];
   }
 }
 

--- a/apps/api/src/tasks/tasks.repository.ts
+++ b/apps/api/src/tasks/tasks.repository.ts
@@ -58,7 +58,7 @@ export class TasksRepository {
             const validatedOwnerName =
               ownerName !== null ? escapeSingleQuote(ownerName) : 'unknown';
             // Build postgis point value then return formatted row
-            const geometry = `'POINT(${coordinateLatitude} ${coordinateLongitude})'`;
+            const geometry = `'POINT(${coordinateLongitude} ${coordinateLatitude})'`;
             // Build licenses data type
             const licensesFmt = formatLicenses(licenses);
 

--- a/apps/website/components/map/Map.vue
+++ b/apps/website/components/map/Map.vue
@@ -242,10 +242,10 @@
       const bounds: LatLngBounds = mapInstance.getBounds();
       const response = await $fetch<AGMapData>(`${apiUrl}/measurements/current/cluster`, {
         params: {
-          xmin: bounds.getSouth(),
-          ymin: bounds.getWest(),
-          xmax: bounds.getNorth(),
-          ymax: bounds.getEast(),
+          xmin: bounds.getWest(),
+          ymin: bounds.getSouth(),
+          xmax: bounds.getEast(),
+          ymax: bounds.getNorth(),
           zoom: mapInstance.getZoom(),
           measure:
             generalConfigStore.selectedMeasure === MeasureNames.PM_AQI

--- a/apps/website/utils/convert-to-geojson.ts
+++ b/apps/website/utils/convert-to-geojson.ts
@@ -25,7 +25,7 @@ export function convertToGeoJSON(
         },
         geometry: {
           type: 'Point',
-          coordinates: [item.latitude, item.longitude]
+          coordinates: [item.longitude, item.latitude]
         }
       };
     })


### PR DESCRIPTION
Previously, latitude and longitude values were mistakenly swapped (lat used as long and vice versa) across the frontend, backend, and database layers. While this “worked” by coincidence, it caused confusion and potential errors in spatial calculations and queries.

[Database]
In `TasksRepository.upsertLocationsAndOwners()`, when creating PostGIS geometry, it used:

`'POINT(latitude longitude)'`

instead of the correct:

`'POINT(longitude latitude)'`

[Backend]
In `measurement.service.ts`, the call to `clustersIndexes.getClusters()` used an incorrect bounding box:

`[yMin, xMin, yMax, xMax]`

instead of:

`[xMin, yMin, xMax, yMax]`

[Frontend]
The `/measurements/current/cluster` API call passed lat/lng values in the wrong order:

`xmin = south, ymin = west, xmax = north, ymax = east`

instead of:

`xmin = west, ymin = south, xmax = east, ymax = north`


[Note]
As far as tested:
- Both `runSyncAirgradientLocations` and `performSyncOpenAQLocations` cron jobs call `upsertLocationsAndOwners`, which updates geometry values — specifically the coordinate column in the public.location table.
- However, only a subset of data is being updated:
  - OLD_AG_BASE_API_URL does not include all existing records in the database.
  - The OpenAQ sync has not been fully tested.
- As a result, some existing rows in the database may still contain incorrect geometries, which can lead to incorrect location rendering on the frontend map.

[Suggested Follow-Up]
With this PR, the system is now forward-compatible — all new and updated data will use the correct coordinate order going forward.

However, only a portion of existing data has been corrected through the current cron jobs. Since some rows in the database still contain geometries with the old (incorrect) coordinate order, map rendering issues may persist for those records.

Recommended action:
Run a one-time data correction script or database migration to update existing entries in the public.location table, ensuring all geometries use the correct POINT(longitude latitude) format.