### PR TITLE
Fix inconsistent history endpoint result

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.9",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "luxon": "^3.7.1",
         "pg": "^8.13.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -3881,6 +3882,15 @@
         "luxon": "~3.5.0"
       }
     },
+    "node_modules/cron/node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -6403,9 +6413,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
-      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.7.9",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "luxon": "^3.7.1",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/apps/api/src/location/location.controller.ts
+++ b/apps/api/src/location/location.controller.ts
@@ -110,7 +110,7 @@ export class LocationController {
   @ApiPaginatedResponse(
     TimeseriesDto,
     'Historical data successfully retrieved',
-    'start and end query format is "yyyy-mm-dd hh:mm" or "yyyy-mm-dd"; bucketsize query follow ISO 8601 duration format',
+    '',
   )
   @ApiBadRequestResponse({ description: 'Invalid date format, bucket size, or date range' })
   @ApiNotFoundResponse({ description: 'Location not found' })

--- a/apps/api/src/location/location.controller.ts
+++ b/apps/api/src/location/location.controller.ts
@@ -115,7 +115,7 @@ export class LocationController {
   @ApiBadRequestResponse({ description: 'Invalid date format, bucket size, or date range' })
   @ApiNotFoundResponse({ description: 'Location not found' })
   @UsePipes(new ValidationPipe({ transform: true }))
-  async getmeasuresHistoryByLocationIdl(
+  async getmeasuresHistoryByLocationId(
     @Param() { id }: FindOneParams,
     @Query() { measure }: MeasureTypeQuery,
     @Query() timeseries: TimeseriesQuery,

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import LocationRepository from './location.repository';
 import { getEPACorrectedPM } from 'src/utils/getEpaCorrectedPM';
+import { BucketSize, roundToBucket } from 'src/utils/timeSeriesBucket';
 
 @Injectable()
 export class LocationService {
@@ -36,10 +37,12 @@ export class LocationService {
   ) {
     // Default set to pm25 if not provided
     let measureType = measure == null ? 'pm25' : measure;
+    let startTime = roundToBucket(start, bucketSize as BucketSize)
+    let endTime = roundToBucket(end, bucketSize as BucketSize)
     const results = await this.locationRepository.retrieveLocationMeasuresHistory(
       id,
-      start,
-      end,
+      startTime.toISO({includeOffset: false}),
+      endTime.toISO({includeOffset: false}),
       bucketSize,
       measureType,
     );

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -39,6 +39,8 @@ export class LocationService {
     let measureType = measure == null ? 'pm25' : measure;
     let startTime = roundToBucket(start, bucketSize as BucketSize)
     let endTime = roundToBucket(end, bucketSize as BucketSize)
+    startTime = startTime.toUTC()
+    endTime = endTime.toUTC()
     const results = await this.locationRepository.retrieveLocationMeasuresHistory(
       id,
       startTime.toISO({includeOffset: false}),

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -1,11 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, InternalServerErrorException} from '@nestjs/common';
 import LocationRepository from './location.repository';
 import { getEPACorrectedPM } from 'src/utils/getEpaCorrectedPM';
 import { BucketSize, roundToBucket } from 'src/utils/timeSeriesBucket';
+import { DateTime } from 'luxon';
 
 @Injectable()
 export class LocationService {
   constructor(private readonly locationRepository: LocationRepository) {}
+  private readonly logger = new Logger(LocationService.name);
 
   async getLocations(page = 1, pagesize = 100) {
     const offset = pagesize * (page - 1); // Calculate the offset for query
@@ -37,14 +39,33 @@ export class LocationService {
   ) {
     // Default set to pm25 if not provided
     let measureType = measure == null ? 'pm25' : measure;
-    let startTime = roundToBucket(start, bucketSize as BucketSize)
-    let endTime = roundToBucket(end, bucketSize as BucketSize)
-    startTime = startTime.toUTC()
-    endTime = endTime.toUTC()
+
+    // Declare and set placeholder
+    let startTime = DateTime.now();
+    let endTime = DateTime.now();
+    try {
+      this.logger.debug(`Time range before processed: ${start} -- ${end}`);
+      startTime = roundToBucket(start, bucketSize as BucketSize);
+      endTime = roundToBucket(end, bucketSize as BucketSize);
+    } catch (error) {
+      this.logger.error(error);
+      throw new InternalServerErrorException({
+        message: `LOC_007: Failed round range timestamp`,
+        operation: 'getLocationMeasuresHistory',
+        parameters: { id, start, end, bucketSize, measure },
+        error: error.message,
+        code: 'LOC_007',
+      });
+    }
+
+    // Need to make sure timestamp in UTC since DB not automatically shift it to UTC
+    startTime = startTime.toUTC();
+    endTime = endTime.toUTC();
+
     const results = await this.locationRepository.retrieveLocationMeasuresHistory(
       id,
-      startTime.toISO({includeOffset: false}),
-      endTime.toISO({includeOffset: false}),
+      startTime.toISO({ includeOffset: false }),
+      endTime.toISO({ includeOffset: false }),
       bucketSize,
       measureType,
     );

--- a/apps/api/src/location/timeseries.dto.ts
+++ b/apps/api/src/location/timeseries.dto.ts
@@ -1,7 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 class Timeseries {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Timestamp of respective value in ISO 8601 format with timezone UTC',
+  })
   timebucket: Date;
 
   @ApiProperty({

--- a/apps/api/src/location/timeseriesQuery.ts
+++ b/apps/api/src/location/timeseriesQuery.ts
@@ -1,29 +1,33 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsString, IsIn } from 'class-validator';
+import { BucketSize } from 'src/utils/timeSeriesBucket';
 
 class TimeseriesQuery {
-  // TODO format with timezone
   @ApiProperty({
-    default: '2025-02-01 00:00',
-    description: 'Start date in format "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"',
+    default: '2025-08-30T20:01:00.000Z',
+    description: 'End date in ISO 8601 format with timezone (eg. 2025-08-30T20:01:00-04:00)',
   })
   @IsString()
   start: string;
 
-  // TODO format with timezone and explain if timezone not included, might inconsistent
   @ApiProperty({
-    default: '2025-02-07 00:00',
-    description: 'End date in format "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"',
+    default: '2025-08-30T20:01:00.000Z',
+    description: 'End date in ISO 8601 format with timezone (eg. 2025-08-30T20:01:00-04:00)',
   })
   @IsString()
   end: string;
 
-  // TODO: follow format of bucketSize enum and validate
-  @ApiProperty({
-    default: '1 D',
-    description: 'Bucket size in ISO 8601 duration format (e.g., "5 M", "1 H", "1 D")',
-  })
+  @ApiProperty({ enum: BucketSize, required: true })
   @IsString()
+  @IsIn(
+    [
+      BucketSize.FifteenMinutes,
+      BucketSize.OneHour,
+      BucketSize.EightHours,
+      BucketSize.OneDay,
+    ],
+    { message: 'Invalid measure parameter' },
+  )
   bucketSize: string;
 }
 export default TimeseriesQuery;

--- a/apps/api/src/location/timeseriesQuery.ts
+++ b/apps/api/src/location/timeseriesQuery.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 
 class TimeseriesQuery {
+  // TODO format with timezone
   @ApiProperty({
     default: '2025-02-01 00:00',
     description: 'Start date in format "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"',
@@ -9,6 +10,7 @@ class TimeseriesQuery {
   @IsString()
   start: string;
 
+  // TODO format with timezone and explain if timezone not included, might inconsistent
   @ApiProperty({
     default: '2025-02-07 00:00',
     description: 'End date in format "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"',
@@ -16,6 +18,7 @@ class TimeseriesQuery {
   @IsString()
   end: string;
 
+  // TODO: follow format of bucketSize enum and validate
   @ApiProperty({
     default: '1 D',
     description: 'Bucket size in ISO 8601 duration format (e.g., "5 M", "1 H", "1 D")',

--- a/apps/api/src/utils/timeSeriesBucket.ts
+++ b/apps/api/src/utils/timeSeriesBucket.ts
@@ -1,0 +1,49 @@
+import { DateTime } from 'luxon';
+
+export enum BucketSize {
+  FifteenMinutes = '15m',
+  OneHour = '1h',
+  EightHours = '8h',
+  OneDay = '1d',
+}
+
+export function roundToBucket(isoString: string, bucketSize: BucketSize): DateTime {
+  // Step 1: Convert the ISO string into a Luxon DateTime object.
+  // Use { setZone: true } to ensure the timezone from the string is respected.
+  const dt = DateTime.fromISO(isoString, { setZone: true });
+
+  // Ensure the conversion was successful before proceeding.
+  if (!dt.isValid) {
+    throw new Error('Invalid ISO date string provided.');
+  }
+
+  switch (bucketSize) {
+    case BucketSize.FifteenMinutes:
+      const totalMinutesForFifteen = dt.hour * 60 + dt.minute;
+      const roundedMinutesForFifteen = Math.floor(totalMinutesForFifteen / 15) * 15;
+      return dt.set({
+        hour: Math.floor(roundedMinutesForFifteen / 60),
+        minute: roundedMinutesForFifteen % 60,
+        second: 0,
+        millisecond: 0,
+      });
+
+    case BucketSize.OneHour:
+      return dt.startOf('hour');
+
+    case BucketSize.EightHours:
+      const roundedHoursForEight = Math.floor(dt.hour / 8) * 8;
+      return dt.set({
+        hour: roundedHoursForEight,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      });
+
+    case BucketSize.OneDay:
+      return dt.startOf('day');
+
+    default:
+      return dt;
+  }
+}

--- a/apps/api/src/utils/timeSeriesBucket.ts
+++ b/apps/api/src/utils/timeSeriesBucket.ts
@@ -8,7 +8,7 @@ export enum BucketSize {
 }
 
 export function roundToBucket(isoString: string, bucketSize: BucketSize): DateTime {
-  // Step 1: Convert the ISO string into a Luxon DateTime object.
+  // Convert the ISO string into a Luxon DateTime object.
   // Use { setZone: true } to ensure the timezone from the string is respected.
   const dt = DateTime.fromISO(isoString, { setZone: true });
 

--- a/apps/website/utils/date.ts
+++ b/apps/website/utils/date.ts
@@ -14,7 +14,7 @@ export function getDateRangeFromToday(
   const end = DateTime.now();
   const start = end.minus({ [unit]: agoCount });
   return {
-    start: start.toISO({ suppressMilliseconds: true, includeOffset: false }),
-    end: end.toISO({ suppressMilliseconds: true, includeOffset: false })
+    start: start.toISO({ suppressMilliseconds: true }),
+    end: end.toISO({ suppressMilliseconds: true })
   };
 }


### PR DESCRIPTION
## Problems

- Because of timezone not properly handled, response not return all data total as it should
- Range timestamp is not rounded based on bucket size, that makes response not always return the same average most of the times

## Changes

- API: Ensure timestamp range is always round down based on bucket size provided
- API: Since `measured_at` column on measurements table is defined without timezone. Range timestamp needs to be converted to UTC first before passing it to query
- Website: Include timezone on timestamp range when request to history endpoint
- API: Update history endpoint docs on swagger
- API: New dependency `Luxon` to manage Date and Time