### PR TITLE
feat: averages endpoint

### DIFF
--- a/apps/api/src/location/averages.dto.ts
+++ b/apps/api/src/location/averages.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PM25Period } from 'src/types';
+
+class AveragesData {
+  @ApiProperty({
+    description: 'Average measurement value for last 6 hours',
+    example: 12.4,
+    nullable: true,
+  })
+  [PM25Period.HOURS_6]: number | null;
+
+  @ApiProperty({
+    description: 'Average measurement value for last 24 hours',
+    example: 14.2,
+    nullable: true,
+  })
+  [PM25Period.HOURS_24]: number | null;
+
+  @ApiProperty({
+    description: 'Average measurement value for last 7 days',
+    example: 16.8,
+    nullable: true,
+  })
+  [PM25Period.DAYS_7]: number | null;
+
+  @ApiProperty({
+    description: 'Average measurement value for last 30 days',
+    example: 18.3,
+    nullable: true,
+  })
+  [PM25Period.DAYS_30]: number | null;
+
+  @ApiProperty({
+    description: 'Average measurement value for last 90 days',
+    example: 20.1,
+    nullable: true,
+  })
+  [PM25Period.DAYS_90]: number | null;
+}
+
+export class PM25AveragesDto {
+  @ApiProperty({
+    description: 'Location identifier',
+    example: 13226,
+  })
+  locationId: number;
+
+  @ApiProperty({
+    description: 'Average measurement values for different time periods',
+    type: AveragesData,
+  })
+  averages: AveragesData;
+
+  constructor(data: { locationId: number; averages: Record<PM25Period, number | null> }) {
+    this.locationId = data.locationId;
+    this.averages = data.averages;
+  }
+}

--- a/apps/api/src/location/location.controller.ts
+++ b/apps/api/src/location/location.controller.ts
@@ -18,6 +18,7 @@ import TimeseriesQuery from './timeseriesQuery';
 import TimeseriesDto from './timeseries.dto';
 import LocationMeasuresDto from './locationMeasures.dto';
 import { CigarettesSmokedDto } from './cigarettesSmoked.dto';
+import { PM25AveragesDto } from './averages.dto';
 
 @Controller('map/api/v1/locations')
 @ApiTags('Locations')
@@ -106,6 +107,33 @@ export class LocationController {
   async getCigarettesSmoked(@Param() { id }: FindOneParams): Promise<CigarettesSmokedDto> {
     const result = await this.locationService.getCigarettesSmoked(id);
     return new CigarettesSmokedDto(result);
+  }
+
+  @Get(':id/averages')
+  @ApiOperation({
+    summary: 'Get measurement averages for a location',
+    description:
+      'Calculate average values for a specified measurement type across different time periods (6h, 24h, 7d, 30d, 90d) for a specific location. Returns null for periods with insufficient data.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Location identifier',
+    example: 12345,
+    type: Number,
+  })
+  @ApiOkResponse({
+    type: PM25AveragesDto,
+    description: 'Measurement averages for multiple time periods',
+  })
+  @ApiNotFoundResponse({ description: 'Location not found or no measurement data available' })
+  @ApiBadRequestResponse({ description: 'Invalid location ID format or measure type' })
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async getLocationPM25Averages(
+    @Param() { id }: FindOneParams,
+    @Query() { measure }: MeasureTypeQuery,
+  ): Promise<PM25AveragesDto> {
+    const result = await this.locationService.getLocationAverages(id, measure);
+    return new PM25AveragesDto(result);
   }
 
   @Get(':id/measures/history')

--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -8,7 +8,9 @@ import {
   LocationByIdResult,
   LocationMeasuresResult,
   CigarettesSmokedResult,
+  PM25AveragesResult,
 } from '../types/location/location.types';
+import { MeasureType } from 'src/types';
 
 @Injectable()
 export class LocationService {
@@ -77,12 +79,16 @@ export class LocationService {
     );
 
     if (measureType === 'pm25') {
-      return results.map(row => ({
+      return results.map((row: any) => ({
         timebucket: row.timebucket,
         value: row.dataSource === 'AirGradient' ? getEPACorrectedPM(row.pm25, row.rhum) : row.pm25,
       }));
     }
 
     return results;
+  }
+
+  async getLocationAverages(id: number, measure: MeasureType): Promise<PM25AveragesResult> {
+    return await this.locationRepository.retrieveAveragesByLocationId(id, measure);
   }
 }

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import DatabaseService from 'src/database/database.service';
 import { MeasurementEntity } from './measurement.entity';
-import { MeasureType } from 'src/utils/measureTypeQuery';
+import { MeasureType } from 'src/types';
 import { getMeasureValidValueRange } from 'src/utils/measureValueValidation';
 
 @Injectable()

--- a/apps/api/src/types/location/location.types.ts
+++ b/apps/api/src/types/location/location.types.ts
@@ -47,3 +47,53 @@ export type LocationMeasuresResult = LocationMeasuresRaw | null;
  * Result type for getCigarettesSmoked service method
  */
 export type CigarettesSmokedResult = Record<string, number>;
+
+/**
+ * PM2.5 time periods for averaging
+ */
+export enum PM25Period {
+  HOURS_6 = '6h',
+  HOURS_24 = '24h',
+  DAYS_7 = '7d',
+  DAYS_30 = '30d',
+  DAYS_90 = '90d',
+}
+
+/**
+ * Configuration for PM2.5 periods
+ */
+export const PM25PeriodConfig = {
+  [PM25Period.HOURS_6]: {
+    interval: '6 hours',
+    label: 'pm25_6h',
+    order: 1,
+  },
+  [PM25Period.HOURS_24]: {
+    interval: '24 hours',
+    label: 'pm25_24h',
+    order: 2,
+  },
+  [PM25Period.DAYS_7]: {
+    interval: '7 days',
+    label: 'pm25_7d',
+    order: 3,
+  },
+  [PM25Period.DAYS_30]: {
+    interval: '30 days',
+    label: 'pm25_30d',
+    order: 4,
+  },
+  [PM25Period.DAYS_90]: {
+    interval: '90 days',
+    label: 'pm25_90d',
+    order: 5,
+  },
+} as const;
+
+/**
+ * Result type for PM2.5 averages
+ */
+export interface PM25AveragesResult {
+  locationId: number;
+  averages: Record<PM25Period, number | null>;
+}

--- a/apps/api/src/types/measurement/measurement.types.ts
+++ b/apps/api/src/types/measurement/measurement.types.ts
@@ -29,7 +29,15 @@ export type MeasurementClusterResult = MeasurementCluster[];
 /**
  * Available measurement types for filtering
  */
-export type MeasureType = 'pm25' | 'pm10' | 'atmp' | 'rhum' | 'rco2' | 'o3' | 'no2';
+export enum MeasureType {
+  PM25 = 'pm25',
+  PM10 = 'pm10',
+  ATMP = 'atmp',
+  RHUM = 'rhum',
+  RCO2 = 'rco2',
+  O3 = 'o3',
+  NO2 = 'no2',
+}
 
 /**
  * Measurement query parameters for area-based searches

--- a/apps/api/src/utils/measureTypeQuery.ts
+++ b/apps/api/src/utils/measureTypeQuery.ts
@@ -1,35 +1,18 @@
-import { IsString, IsIn, IsOptional } from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-
-export enum MeasureType {
-  PM25 = 'pm25',
-  PM10 = 'pm10',
-  ATMP = 'atmp',
-  RHUM = 'rhum',
-  RCO2 = 'rco2',
-  O3 = 'o3',
-  NO2 = 'no2',
-}
+import { MeasureType } from '../types';
 
 class MeasureTypeQuery {
-  @ApiProperty({ enum: MeasureType, required: false })
+  @ApiProperty({
+    enum: MeasureType,
+    required: false,
+    description: 'Type of measurement to filter by',
+  })
   @IsOptional()
-  @IsString()
-  @IsIn(
-    [
-      MeasureType.PM25,
-      MeasureType.PM10,
-      MeasureType.ATMP,
-      MeasureType.RHUM,
-      MeasureType.RCO2,
-      MeasureType.O3,
-      MeasureType.NO2,
-    ],
-    { message: 'Invalid measure parameter' },
-  )
+  @IsEnum(MeasureType, { message: 'Invalid measure parameter' })
   @Transform(({ value }) => value?.toLowerCase())
-  measure: string;
+  measure?: MeasureType;
 }
 
 export default MeasureTypeQuery;

--- a/apps/api/src/utils/measureValueValidation.ts
+++ b/apps/api/src/utils/measureValueValidation.ts
@@ -1,4 +1,4 @@
-import { MeasureType } from './measureTypeQuery';
+import { MeasureType } from 'src/types';
 import * as Constants from '../constants';
 import { MeasureValueValidationConfig } from 'src/types/shared/measure-value-validation';
 


### PR DESCRIPTION
- Added /locations/:id/averages endpoint to calculate measurement
  averages for different time periods (6h, 24h, 7d, 30d, 90d)
  - Added MeasureType enum supporting PM2.5, PM10, temperature,
  humidity, CO2, O3, NO2