### PR TITLE
Docker compose for staging environment

### DIFF
--- a/apps/api/tools/docker/Dockerfile
+++ b/apps/api/tools/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apk add --no-cache dumb-init
 COPY --from=builder --chown=nestjs:nodejs /app/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /app/package*.json ./
+COPY --from=builder --chown=nestjs:nodejs /app/tsconfig*.json ./
 
 # Switch to non-root user
 USER nestjs

--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:22-alpine AS build
 WORKDIR /app
 
+# Accept APP_ENV as build argument
+ARG APP_ENV=development
+ENV APP_ENV=$APP_ENV
+
 COPY package.json package-lock.json .npmrc ./
 
 RUN npm install --ignore-scripts \
@@ -12,13 +16,13 @@ COPY . .
 
 RUN npm run build
 
-
 FROM node:22-alpine
 WORKDIR /app
 
 COPY --from=build /app/.output/ ./
 
-ENV NODE_ENV=production
+ARG APP_ENV=development
+ENV APP_ENV=$APP_ENV
 ENV HOST=0.0.0.0
 ENV PORT=80
 

--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -4,9 +4,9 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiUrl:
-        process.env.NODE_ENV === 'production'
+        process.env.APP_ENV === 'production'
           ? 'https://map-data.airgradient.com/map/api/v1'
-          : process.env.NODE_ENV === 'staging'
+          : process.env.APP_ENV === 'staging'
             ? 'https://map-data-int.airgradient.com/map/api/v1'
             : 'http://localhost:3001/map/api/v1'
     }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -23,18 +23,17 @@ services:
     build:
       context: apps/api
       dockerfile: tools/docker/Dockerfile
-      target: development
     restart: unless-stopped
     ports:
       - 3001:3001
     networks:
       - dev 
-    env_file:
-      - ./apps/api/.env.development
+    volumes:
+      - ./apps/api/src:/app/src
+      - ./apps/api/.env.development:/app/.env.development
+    command: npm run start:dev
     depends_on:
       - postgrex
-    environment:
-      - NODE_ENV=development
 
   app:
     container_name: website-mono

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,0 +1,58 @@
+# API
+services:
+  postgrex:
+    container_name: postgrex-mono
+    build:
+      context: apps/api/tools/docker/db
+      dockerfile: Dockerfile
+      args:
+        - CRON_DATABASE_NAME=${DATABASE_NAME}
+    restart: unless-stopped
+    expose:
+      - 5432
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
+      - POSTGRES_DB=${DATABASE_NAME}
+      - POSTGRES_USER=${DATABASE_USER}
+    networks:
+      - airgradient-map-staging
+
+  mapapi:
+    container_name: mapapi-mono
+    build:
+      context: apps/api
+      dockerfile: tools/docker/Dockerfile
+    restart: unless-stopped
+    ports:
+      - 3001:3001
+    networks:
+      - airgradient-map-staging
+    env_file:
+      - ./apps/api/.env.staging
+    depends_on:
+      - postgrex
+    environment:
+      - NODE_ENV=staging
+
+  app:
+    container_name: website-mono
+    build:
+      context: apps/website
+      args:
+        - APP_ENV=staging
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+    environment:
+      - APP_ENV=staging
+      - HOST=0.0.0.0
+      - PORT=80
+
+networks:
+  airgradient-map-staging:
+    driver: bridge
+
+volumes:
+  pgdata:

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -8,8 +8,8 @@ services:
       args:
         - CRON_DATABASE_NAME=${DATABASE_NAME}
     restart: unless-stopped
-    expose:
-      - 5432
+    ports:
+      - 9876:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,11 +41,13 @@ services:
     container_name: website-mono
     build:
       context: apps/website
+      args:
+        - APP_ENV=staging
     restart: unless-stopped
     ports:
       - "3000:80"
     environment:
-      - NODE_ENV=production
+      - APP_ENV=staging
       - HOST=0.0.0.0
       - PORT=80
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,12 +42,12 @@ services:
     build:
       context: apps/website
       args:
-        - APP_ENV=staging
+        - APP_ENV=production
     restart: unless-stopped
     ports:
       - "3000:80"
     environment:
-      - APP_ENV=staging
+      - APP_ENV=production
       - HOST=0.0.0.0
       - PORT=80
 


### PR DESCRIPTION
## Changes

1. Add docker compose for staging environment
2. [API] Fix Dockerfile that failed to run when running in dev
3. [Website] Fix API URL configuration for staging and production environment. Nuxt's `runtimeConfig.public` values are resolved at build time for SSR apps, not at runtime. Additionally, Nuxt automatically overrides `NODE_ENV` to `production` during builds for optimization purposes, causing our environment-based API URL logic to always use the production endpoint. Solution: Replace `NODE_ENV` with `APP_ENV` in Docker configuration to properly distinguish between staging and production environments during the build process.

#### References

- https://nuxt.com/docs/4.x/api/commands/build
- https://github.com/nuxt/nuxt/issues/19819



