### PR TITLE
Improve query performance of retrieve latest measures by area 

### DIFF
--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -147,7 +147,11 @@ class MeasurementRepository {
                         ST_MakeEnvelope($1, $2, $3, $4, 3857)
                     )
                 AND
+                  ${whereQuery}
+                AND
                     m.measured_at  >= NOW() - INTERVAL '6 hours'
+                AND
+                    m.measured_at <= NOW()
                 GROUP BY 
                     l.id
             )
@@ -163,10 +167,12 @@ class MeasurementRepository {
             FROM 
                 latest_measurements lm
             JOIN 
-                measurement m ON lm.location_id = m.location_id AND lm.last_measured_at = m.measured_at
+                measurement m ON
+                    lm.location_id = m.location_id
+                    AND lm.last_measured_at = m.measured_at
+                    AND m.measured_at >= NOW() - INTERVAL '6 hours'
             JOIN 
-                location l ON m.location_id = l.id
-                ${whereQuery};
+                location l ON m.location_id = l.id;
         `;
 
     try {

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -21,7 +21,7 @@ class MeasurementRepository {
   } {
     const query = {
       selectQuery: `m.pm25, m.pm10, m.atmp, m.rhum, m.rco2, m.o3, m.no2`,
-      whereQuery: '',
+      whereQuery: '1=1',
       hasValidation: false,
       minVal: null,
       maxVal: null,
@@ -40,10 +40,10 @@ class MeasurementRepository {
 
       if (measure === MeasureType.PM25) {
         query.selectQuery = `m.pm25, m.rhum`;
-        query.whereQuery = `WHERE m.pm25 IS NOT NULL ${validationQuery}`;
+        query.whereQuery = `m.pm25 IS NOT NULL ${validationQuery}`;
       } else {
         query.selectQuery = `m.${measure}`;
-        query.whereQuery = `WHERE m.${measure} IS NOT NULL ${validationQuery}`;
+        query.whereQuery = `m.${measure} IS NOT NULL ${validationQuery}`;
       }
     }
     return query;
@@ -89,7 +89,8 @@ class MeasurementRepository {
                 measurement m ON lm.location_id = m.location_id AND lm.last_measured_at = m.measured_at
             JOIN 
                 location l ON m.location_id = l.id
-            ${whereQuery}
+            WHERE
+              ${whereQuery}
             ORDER BY 
                 lm.location_id 
             OFFSET $1 LIMIT $2; 


### PR DESCRIPTION
## Impact

Retrieve latest measures by area query right now can take up to 7s if the area is worldwide, this is taking too long. The need to improve this because the increase of total locations and measurement data.

#### Impacted endpoints:

- `/current/area`
- `/current/cluster`

## Changes

- Includes partition pruning optimization
  - upper bound condition (`m.measured_at <= NOW()`) in CTE
  - Redundant time filter after CTE (`m.measured_at >= NOW() - INTERVAL '6 hours'`)
- Earlier filtering measure type conditioning (_Condition check happen on CTE not after_)

### Result

- **Before**
  - **Execution Time:** 8,059.237 ms
  - **Total Cost:** 1,299,927.84
- **After**
  - **Execution Time:** 165.081 ms
  - **Total Cost :** 193,695.49

**Execution Time Percentage reduction:** ≈ **97.95%**
**Total Cost Percentage reduction:** ≈ **85.09%**

## Notes

To give further improvement, adding GIS indexing to `location.coordinate` column will improve overall query execution time and, but its not more than 15% (on top of this query changes). For more detail, please see below

There's still `sequential scan` on the query explain, so there's still room for improvement.

---

# Improve query performance of retrieve latest measures by area 

## Query Summary

**Query 1**: existing-query.dbplan  
- No partition pruning optimization 
- PM2.5 filter moved to final WHERE clause
- No GIST index on coordinate column

**Query 2**: partition-prune-earlier-filter.dbplan  
- Includes partition pruning optimization
  - upper bound condition (`m.measured_at <= NOW()`) in CTE
  - Redundant time filter after CTE (`m.measured_at >= NOW() - INTERVAL '6 hours'`)
- Earlier filtering measure type conditioning (_Condition check happen on CTE not after_)
- No GIST index on coordinate column

**Query 3**: add-gis-index.dbplan  
- Includes partition pruning optimization
  - upper bound condition (`m.measured_at <= NOW()`) in CTE
  - Redundant time filter after CTE (`m.measured_at >= NOW() - INTERVAL '6 hours'`)
- Earlier filtering measure type conditioning (_Condition check happen on CTE not after_)
- Has GIST index on coordinate column


## Key Metrics

| Metric | Query 1 | Query 2 | Query 3 |
|--------|---------|---------|---------|
| **Execution Time** | 8,059.237 ms | 165.081 ms | 141.501 ms |
| **Total Cost** | 1,299,927.84 | 193,695.49 | 134,735.69 |
| **Rows Returned** | 4,006 | 4,053 | 4,053 |
| **Rows Scanned** | 33,329,258 | 65,440 | 65,585 |
| **Partitions Pruned** | 0 | 29 or 35 | 29 or 35 |
| **Spatial Filter Cost** | 177,460.50 | 177,460.50 | 120,601.75 |

## Query 1: Execution Plan Breakdown

| Level | Operation | Type | Rows (Est/Act) | Time (ms) | Cost | Condition |
|-------|-----------|------|----------------|-----------|------|-----------|
| **1** | Root | Hash Join | 7,985,960 / 4,006 | 8,059.237 | 1,299,927.84 | `l_1.id = l.id` |
| ├─ 2 | Hash Join | Inner | 7,985,960 / 4,006 | 7,693.006 | 1,238,266.24 | `m.location_id = l_1.id AND m.measured_at = LAST(m_37.measured_at, m_37.measured_at)` |
| │ ├─ 3 | Append | - | 33,333,861 / 33,329,258 | 5,151.223 | 871,543.91 | - |
| │ │ ├─ 4 | Seq Scan | measurement_p20250221 | 11 / 11 | 0.037 | 1.11 | Filter: `pm25 IS NOT NULL` |
| │ │ ├─ 4 | Seq Scan | measurement_p20250328 | 1,072,569 / 1,073,525 | 109.695 | 22,692.37 | Filter: `pm25 IS NOT NULL` |
| │ │ ├─ 4 | Seq Scan | measurement_p20250404 | 1,174,525 / 1,174,526 | 110.851 | 24,732.87 | Filter: `pm25 IS NOT NULL` |
| │ │ ├─ 4 | Seq Scan | measurement_p20250411 | 1,195,878 / 1,196,210 | 111.072 | 25,210.02 | Filter: `pm25 IS NOT NULL` |
| │ │ └─ 4 | (32 more partitions) | Seq Scan | - | - | - | Filter: `pm25 IS NOT NULL` |
| │ └─ 3 | Hash | - | 9,583 / 4,021 | 101.198 | 191,565.62 | - |
| │   └─ 4 | Aggregate | Hashed | 9,583 / 4,021 | 100.425 | 191,565.62 | GROUP BY `l_1.id` |
| │     └─ 5 | Hash Join | Inner | 35,750 / 47,204 | 36.950 | 180,047.16 | `m_37.location_id = l_1.id` |
| │       ├─ 6 | Append | - | 52,787 / 65,415 | 22.270 | 2,328.26 | - |
| │       │ └─ 7 | Index Scan | measurement_p20250912 | 51,279 / 65,415 | 17.914 | 1,828.95 | `measured_at >= NOW() - INTERVAL '6 hours'` |
| │       └─ 6 | Hash | - | 9,583 / 9,512 | 5.304 | 177,460.50 | - |
| │         └─ 7 | Seq Scan | location | 9,583 / 9,512 | 4.246 | 177,460.50 | `ST_Within(coordinate, ST_MakeEnvelope(...))` |
| └─ 2 | Hash | - | 14,150 / 14,150 | 364.779 | 585.50 | - |
|   └─ 3 | Seq Scan | location | 14,150 / 14,150 | 362.675 | 585.50 | - |

## Query 2: Execution Plan Breakdown

| Level | Operation | Type | Rows (Est/Act) | Time (ms) | Cost | Condition |
|-------|-----------|------|----------------|-----------|------|-----------|
| **1** | Root | Hash Join | 10,066 / 4,053 | 165.081 | 193,695.49 | `l_1.id = l.id` |
| ├─ 2 | Hash Join | Inner | 10,066 / 4,053 | 133.162 | 192,856.35 | `l_1.id = m.location_id AND LAST(m_8.measured_at, m_8.measured_at) = m.measured_at` |
| │ ├─ 3 | Aggregate | Sorted | 9,583 / 4,053 | 102.840 | 190,250.13 | GROUP BY `l_1.id` |
| │ │ └─ 4 | Sort | quicksort | 24,864 / 46,898 | 45.879 | 181,480.39 | Sort Key: `l_1.id`, Memory: 3368 KB |
| │ │   └─ 5 | Hash Join | Inner | 24,864 / 46,898 | 32.766 | 179,602.94 | `m_8.location_id = l_1.id` |
| │ │     ├─ 6 | Append | - | 36,714 / 64,950 | 20.379 | 1,926.24 | - |
| │ │     │ └─ 7 | Index Scan | measurement_p20250912 | 36,664 / 64,950 | 16.343 | 1,454.61 | `measured_at >= NOW() - INTERVAL '6 hours' AND measured_at <= NOW()` Filter: `pm25 IS NOT NULL` |
| │ │     └─ 6 | Hash | - | 9,583 / 9,512 | 4.400 | 177,460.50 | - |
| │ │       └─ 7 | Seq Scan | location | 9,583 / 9,512 | 3.418 | 177,460.50 | `ST_Within(coordinate, ST_MakeEnvelope(...))` |
| │ └─ 3 | Hash | - | 42,015 / 65,440 | 28.300 | 1,925.68 | Memory: 4088 KB |
| │   └─ 4 | Append | - | 42,015 / 65,440 | 19.511 | 1,925.68 | - |
| │     ├─ 5 | Index Scan | measurement_p20250912 | 40,507 / 65,440 | 15.510 | 1,480.23 | `measured_at >= NOW() - INTERVAL '6 hours'` |
| │     └─ 5 | (6 more partitions) | Various | - | - | - | - |
| └─ 2 | Hash | - | 14,150 / 14,150 | 29.911 | 585.50 | - |
|   └─ 3 | Seq Scan | location | 14,150 / 14,150 | 28.042 | 585.50 | - |

## Query 3: Execution Plan Breakdown

| Level | Operation | Type | Rows (Est/Act) | Time (ms) | Cost | Condition |
|-------|-----------|------|----------------|-----------|------|-----------|
| **1** | Root | Hash Join | 10,175 / 4,053 | 141.501 | 134,735.69 | `l_1.id = l.id` |
| ├─ 2 | Hash Join | Inner | 10,175 / 4,053 | 123.257 | 133,895.72 | `m.location_id = l_1.id AND m.measured_at = LAST(m_8.measured_at, m_8.measured_at)` |
| │ ├─ 3 | Append | - | 42,471 / 65,585 | 19.698 | 1,940.70 | - |
| │ │ ├─ 4 | Index Scan | measurement_p20250912 | 40,963 / 65,585 | 15.668 | 1,492.96 | `measured_at >= NOW() - INTERVAL '6 hours'` |
| │ │ └─ 4 | (6 more partitions) | Various | - | - | - | - |
| │ └─ 3 | Hash | - | 9,583 / 4,053 | 98.271 | 131,588.29 | - |
| │   └─ 4 | Aggregate | Hashed | 9,583 / 4,053 | 97.609 | 131,588.29 | GROUP BY `l_1.id` |
| │     └─ 5 | Hash Join | Inner | 25,091 / 47,051 | 36.835 | 122,761.24 | `m_8.location_id = l_1.id` |
| │       ├─ 6 | Append | - | 37,049 / 65,095 | 23.404 | 1,942.41 | - |
| │       │ └─ 7 | Index Scan | measurement_p20250912 | 36,999 / 65,095 | 19.294 | 1,469.11 | `measured_at >= NOW() - INTERVAL '6 hours' AND measured_at <= NOW()` Filter: `pm25 IS NOT NULL` |
| │       └─ 6 | Hash | - | 9,583 / 9,512 | 3.981 | 120,601.75 | - |
| │         └─ 7 | Bitmap Heap Scan | location | 9,583 / 9,512 | 3.272 | 120,601.75 | `ST_Within(coordinate, ST_MakeEnvelope(...))` |
| │           └─ 8 | Bitmap Index Scan | idx_location_coordinate_gist | 9,583 / 9,512 | 0.524 | 272.02 | `coordinate @ ST_MakeEnvelope(...)` |
| └─ 2 | Hash | - | 14,150 / 14,150 | 16.419 | 585.50 | - |
|   └─ 3 | Seq Scan | location | 14,150 / 14,150 | 14.712 | 585.50 | - |


